### PR TITLE
Fix preview content overflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,6 +99,7 @@
             border-radius: 5px;
             margin: 10px 0;
             padding: 10px;
+            overflow-x: auto; /* Enable horizontal scrolling */
         }
 
         th {


### PR DESCRIPTION
Add horizontal scrolling to preview sections in `index.html`.

* Add `overflow-x: auto` to the `pre` elements for `file-preview` and `converted-preview` to enable horizontal scrolling when content is too wide.

